### PR TITLE
Add authors of RFC 8229 to Acknowledgments

### DIFF
--- a/draft-ietf-ipsecme-rfc8229bis.xml
+++ b/draft-ietf-ipsecme-rfc8229bis.xml
@@ -1356,7 +1356,7 @@
         </section>
 
         <section title="Acknowledgments" numbered="no" anchor="acknowledgments">
-          <t>The following people authored RFC8229: Tommy Pauly, Samy Touati and Ravi Mantha.
+          <t>Thanks to the original authors of RFC8229, Tommy Pauly, Samy Touati, and Ravi Mantha.
           Since this document is an update for RFC 8229, most of its text was borrowed
           from this RFC.
           </t>

--- a/draft-ietf-ipsecme-rfc8229bis.xml
+++ b/draft-ietf-ipsecme-rfc8229bis.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
 
-<rfc category="std" ipr="trust200902" docName="draft-ietf-ipsecme-rfc8229bis-01" obsoletes="8229">
+<rfc category="std" ipr="trust200902" docName="draft-ietf-ipsecme-rfc8229bis-02" obsoletes="8229">
 
 <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
 
@@ -1356,6 +1356,11 @@
         </section>
 
         <section title="Acknowledgments" numbered="no" anchor="acknowledgments">
+          <t>The following people authored RFC8229: Tommy Pauly, Samy Touati and Ravi Mantha.
+          Since this document is an update for RFC 8229, most of its text was borrowed
+          from this RFC.
+          </t>
+
           <t>The following people provided valuable feedback and advices while preparing RFC8229:
           Stuart Cheshire, Delziel Fernandes, Yoav Nir, Christoph Paasch, Yaron
           Sheffer, David Schinazi, Graham Bartlett, Byju Pularikkal, March Wu,

--- a/draft-ietf-ipsecme-rfc8229bis.xml
+++ b/draft-ietf-ipsecme-rfc8229bis.xml
@@ -1357,8 +1357,8 @@
 
         <section title="Acknowledgments" numbered="no" anchor="acknowledgments">
           <t>Thanks to the original authors of RFC8229, Tommy Pauly, Samy Touati, and Ravi Mantha.
-          Since this document is an update for RFC 8229, most of its text was borrowed
-          from this RFC.
+          Since this document updates and obsoletes RFC 8229, most of its text was borrowed
+          from the original document.
           </t>
 
           <t>The following people provided valuable feedback and advices while preparing RFC8229:


### PR DESCRIPTION
Original authors of RFC 8229 are added to Acknowledgments section